### PR TITLE
Reset appropriate parameters when fine tuning

### DIFF
--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -200,7 +200,12 @@ def load_checkpoint(model, optimizer, lr_scheduler, load_arg='load'):
         tracker_filename)
 
     if args.deepspeed:
-        checkpoint_name, state_dict = model.load_checkpoint(load_dir)
+        checkpoint_name, state_dict = model.load_checkpoint(load_dir,
+                                                            load_optimizer_states=not args.no_load_optim
+                                                                                  and not args.finetune,
+                                                            load_lr_scheduler_states=not args.override_lr_scheduler
+                                                                                     and not args.finetune,
+                                                            finetune=args.finetune)
 
         if checkpoint_name is None:
             if mpu.get_data_parallel_rank() == 0:


### PR DESCRIPTION
The `--finetune`, `--no_load_optim`, and `--override_lr_scheduler` arguments do not work correctly when DeepSpeed is enabled. The `--no_load_optim`, and `--override_lr_scheduler` arguments are simply ignored and have no effect. The `--finetune` argument does reset Megatron-LM's iteration counter, but it does not do the following as it should:
1. Reset the learning rate schedule,
2. Reset the loss scale parameter, and
3. Reset the global steps counter

I'm not sure which version(s) of the Megatron-LM DeepSpeed integration I should be working with. Is https://github.com/microsoft/DeepSpeedExamples/tree/25d73cf73fb3dc66faefa141b7319526555be9fc/Megatron-LM-v1.1.5-the latest? It appears to have the same issue, however.

This pull request depends on https://github.com/microsoft/DeepSpeed/pull/1160